### PR TITLE
ログイン時の表示画面の切替

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
-  # before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   #protected
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
 
+  skip_before_action :authenticate_user!, only: [:index, :show]
+
   def index
     @items = Item.on_sell.includes([:images]).order(created_at: :desc)
   end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -13,8 +13,11 @@
           = link_to "カテゴリー", root_path, class:"headboxUnder__search--left"
           = link_to "ブランド", root_path, class:"headboxUnder__search--right"
         .headboxUnder__user
-          = link_to "ログイン", new_user_session_path, class:"headboxUnder__user__login"
-          = link_to "新規会員登録",new_user_registration_path, class:"headboxUnder__user__register"
+          - if user_signed_in?
+            = link_to "マイページ", "/users/#{current_user.id}", class:"headboxUnder__user__mypage"
+          - else
+            = link_to "ログイン", new_user_session_path, class:"headboxUnder__user__login"
+            = link_to "新規会員登録",new_user_registration_path, class:"headboxUnder__user__register"
 
   .top-contents
     .topInfo

--- a/app/views/users/card.html.haml
+++ b/app/views/users/card.html.haml
@@ -1,7 +1,7 @@
 .mypage-nav
   %ul.page-lists
     %li.page-lists__list
-      = link_to "root_path" do 
+      = link_to "/" do
         freemarket
         = icon('fa', 'angle-right', class: 'icon')
     %li.page-lists__list--2

--- a/app/views/users/delivery_address.html.haml
+++ b/app/views/users/delivery_address.html.haml
@@ -1,7 +1,7 @@
 .mypage-nav
   %ul.page-lists
     %li.page-lists__list
-      = link_to "root_path" do 
+      = link_to "/" do
         freemarket
         = icon('fa', 'angle-right', class: 'icon')
     %li.page-lists__list--2

--- a/app/views/users/log_out.html.haml
+++ b/app/views/users/log_out.html.haml
@@ -1,7 +1,7 @@
 .mypage-nav
   %ul.page-lists
     %li.page-lists__list
-      = link_to "root_path" do 
+      = link_to "/" do
         freemarket
         = icon('fa', 'angle-right', class: 'icon')
     %li.page-lists__list--2
@@ -43,9 +43,11 @@
 
   .main__right
     .logout-form
-      = form_with url: destroy_user_session_path, method: :delete do |f|
-        .field-input
-          = f.submit 'ログアウト', class: 'submit-btn'
+      .field-input
+        = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'submit-btn'
+      -#= form_with url: destroy_user_session_path, method: :delete do |f|
+        -#.field-input
+          -#= f.submit 'ログアウト', class: 'submit-btn'
 
 .sell-btn
   .btn-title

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 .mypage-nav
   %ul.page-lists
     %li.page-lists__list
-      = link_to "root_path" do 
+      = link_to "/" do
         freemarket
         = icon('fa', 'angle-right', class: 'icon')
     %li.page-lists__list--2
@@ -46,7 +46,7 @@
         .user-face
           = image_tag src="/assets/icon/member_photo_noimage_thumb.png", size: "60x60"
         %h2.user-name
-          マキ
+          = current_user.nickname
         .user-information
           .judge
             評価

--- a/app/views/users/user_information.html.haml
+++ b/app/views/users/user_information.html.haml
@@ -1,7 +1,7 @@
 .mypage-nav
   %ul.page-lists
     %li.page-lists__list
-      = link_to "root_path" do 
+      = link_to "/" do
         freemarket
         = icon('fa', 'angle-right', class: 'icon')
     %li.page-lists__list--2


### PR DESCRIPTION
# What
 - ログイン時とログアウト時で表示を切り替える。
 - 各ページの遷移先を設定する。
# Why
 - ユーザビリティの向上のため。
# Preview
ログアウト時
[![Screenshot from Gyazo](https://gyazo.com/88d32a70f135d55c2c67329ac025a5d6/raw)](https://gyazo.com/88d32a70f135d55c2c67329ac025a5d6)
---
ログイン時
[![Screenshot from Gyazo](https://gyazo.com/2cc6bf6c46f5b816a4351c409112b8a0/raw)](https://gyazo.com/2cc6bf6c46f5b816a4351c409112b8a0)
---
ニックネームを表示
[![Screenshot from Gyazo](https://gyazo.com/11923baf2b8efe0d3600015bf44f7995/raw)](https://gyazo.com/11923baf2b8efe0d3600015bf44f7995)
---