### PR TITLE
複数画像投稿の実装

### DIFF
--- a/app/assets/javascripts/image-upload.js
+++ b/app/assets/javascripts/image-upload.js
@@ -2,7 +2,7 @@ $(document).on('turbolinks:load', ()=> {
   const buildFileField = (index) => {
     const html = `
       <div data-index="${index}" class="img-file_group">
-        <input class="img-file" type="file" name="item[item_images_attributes][${index}][image]" id=#item_images_attributes_${index}_image"><br>
+        <input class="img-file" type="file" name="item[images_attributes][${index}][image]" id=#item_images_attributes_${index}_image"><br>
         <div class="exhibit__drop-box__previews__preview__delete img-remove">
           削除
         </div>


### PR DESCRIPTION
# What
　出品商品の画像を複数枚投稿できるようにする。
# Why
　商品の写真を多く表示できることで、取引の充実を図るため。